### PR TITLE
New script to get all the resolved issues in a release

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,25 @@
 
 A collection of tools for managing Jira issues for the RHODS project
 
+# get_release_issues.py
+
+This script returns all the issues in a specific release.
+
+## Usage
+
+```bash
+python get_release_issues.py \
+  --token-file /path/to/file/with/jira/personal/token \
+  --release "The release to get all the issues from" # e.g. RHODS_1.6.0_GA
+```
+
+In combination with `awk` it can be used to format the input of the scripts
+below.
+
+```bash
+python get_release_issues.py ... | awk '{ printf " --issue %s", $1 }'
+```
+
 # move_to_qa.py
 
 This script handles transitioning a given Jira issue to the "Ready for QA"

--- a/get_release_issues.py
+++ b/get_release_issues.py
@@ -1,0 +1,35 @@
+#! /usr/bin/env python3
+
+import argparse
+import os
+
+from jira import JIRA
+
+JIRA_PROJECT = 'RHODS'
+ISSUE_STATUS_FILTER = 'Resolved'
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-t', '--token-file', required=True,
+                        help='Path to a file containing the JIRA personal access token')
+    parser.add_argument('-b', '--release', required=True,
+                        help='The specific release to get all the issues from')
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    assert os.path.exists(args.token_file)
+    with open(args.token_file) as f:
+        token = f.read().strip()
+
+    jira = JIRA('https://issues.redhat.com', token_auth=token)
+    issues_in_release = jira.search_issues(
+        'Project={} AND "Target Release"={} AND Status="{}"'.format(
+            JIRA_PROJECT, args.release, ISSUE_STATUS_FILTER))
+
+    for issue in issues_in_release:
+        print(issue.key)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
I tested this with release 1.6.0 and the result is:

```shell
$ python get_release_issues.py --token-file ../jira-token.txt --release "RHODS_1.6.0_GA" | awk '{ printf " --issue %s", $1 }'
 --issue RHODS-2728 --issue RHODS-2427 --issue RHODS-2425 --issue RHODS-2364 --issue RHODS-2327 --issue RHODS-2326 --issue RHODS-1953 --issue RHODS-783 --issue RHODS-734
```
